### PR TITLE
Add anchor links to article headings

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,8 +1,11 @@
 // @ts-check
 import { defineConfig } from "astro/config";
 import mdx from "@astrojs/mdx";
+import rehypeSlug from "rehype-slug";
+import rehypeAutolinkHeadings from "rehype-autolink-headings";
 
 import { remarkYouTubeEmbed } from "./src/lib/remark-youtube-embed.ts";
+import { anchorLinkIcon } from "./src/lib/anchor-link-icon.ts";
 
 // https://astro.build/config
 export default defineConfig({
@@ -10,6 +13,20 @@ export default defineConfig({
 
   markdown: {
     remarkPlugins: [remarkYouTubeEmbed],
+    rehypePlugins: [
+      rehypeSlug,
+      [
+        rehypeAutolinkHeadings,
+        {
+          behavior: "append",
+          properties: {
+            class: "anchor-link",
+            ariaLabel: "Link to this section",
+          },
+          content: anchorLinkIcon,
+        },
+      ],
+    ],
   },
 
   prefetch: {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@justinribeiro/lite-youtube": "^1.9.0",
     "@lucide/astro": "^0.563.0",
     "astro": "5.16.15",
+    "rehype-autolink-headings": "^7.1.0",
+    "rehype-slug": "^6.0.0",
     "sharp": "^0.34.5",
     "unist-util-visit": "^5.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       astro:
         specifier: 5.16.15
         version: 5.16.15(@types/node@25.0.2)(jiti@2.6.1)(rollup@4.57.0)(typescript@5.9.3)(yaml@2.8.2)
+      rehype-autolink-headings:
+        specifier: ^7.1.0
+        version: 7.1.0
+      rehype-slug:
+        specifier: ^6.0.0
+        version: 6.0.0
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -1384,6 +1390,9 @@ packages:
   hast-util-from-parse5@8.0.3:
     resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
 
+  hast-util-heading-rank@3.0.0:
+    resolution: {integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==}
+
   hast-util-is-element@3.0.0:
     resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
 
@@ -1404,6 +1413,9 @@ packages:
 
   hast-util-to-parse5@8.0.1:
     resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
+
+  hast-util-to-string@3.0.1:
+    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
 
   hast-util-to-text@4.0.2:
     resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
@@ -1936,6 +1948,9 @@ packages:
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
+  rehype-autolink-headings@7.1.0:
+    resolution: {integrity: sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==}
+
   rehype-parse@9.0.1:
     resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
 
@@ -1944,6 +1959,9 @@ packages:
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  rehype-slug@6.0.0:
+    resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
 
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
@@ -3937,6 +3955,10 @@ snapshots:
       vfile-location: 5.0.3
       web-namespaces: 2.0.1
 
+  hast-util-heading-rank@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-is-element@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -4025,6 +4047,10 @@ snapshots:
       space-separated-tokens: 2.0.2
       web-namespaces: 2.0.1
       zwitch: 2.0.4
+
+  hast-util-to-string@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
 
   hast-util-to-text@4.0.2:
     dependencies:
@@ -4806,6 +4832,15 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
+  rehype-autolink-headings@7.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-is-element: 3.0.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+
   rehype-parse@9.0.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -4825,6 +4860,14 @@ snapshots:
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
+
+  rehype-slug@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      github-slugger: 2.0.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-to-string: 3.0.1
+      unist-util-visit: 5.1.0
 
   rehype-stringify@10.0.1:
     dependencies:

--- a/src/layouts/Article.astro
+++ b/src/layouts/Article.astro
@@ -148,4 +148,60 @@ const { title, summary, published, id, image } = Astro.props;
       }
     }
   }
+
+  /* Anchor link styles for article headings */
+  main :global(h1),
+  main :global(h2),
+  main :global(h3),
+  main :global(h4),
+  main :global(h5),
+  main :global(h6) {
+    scroll-margin-top: 5rem;
+  }
+
+  main :global(.anchor-link) {
+    margin-left: 0.5rem;
+    color: var(--color-interactive);
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    vertical-align: middle;
+
+    /* Override external link arrow from global styles */
+    &::after {
+      content: none !important;
+    }
+
+    &:focus-visible {
+      opacity: 1;
+      outline: 2px solid var(--color-interactive);
+      outline-offset: 2px;
+      border-radius: 2px;
+    }
+  }
+
+  /* Desktop: show on heading hover */
+  @media (hover: hover) {
+    main :global(h1:hover .anchor-link),
+    main :global(h2:hover .anchor-link),
+    main :global(h3:hover .anchor-link),
+    main :global(h4:hover .anchor-link),
+    main :global(h5:hover .anchor-link),
+    main :global(h6:hover .anchor-link) {
+      opacity: 1;
+    }
+  }
+
+  /* Touch devices: always visible at reduced opacity */
+  @media (hover: none) {
+    main :global(.anchor-link) {
+      opacity: 0.5;
+    }
+  }
+
+  /* Respect reduced motion preference */
+  @media (prefers-reduced-motion: reduce) {
+    main :global(.anchor-link) {
+      transition: none;
+    }
+  }
 </style>

--- a/src/layouts/Article.astro
+++ b/src/layouts/Article.astro
@@ -150,12 +150,7 @@ const { title, summary, published, id, image } = Astro.props;
   }
 
   /* Anchor link styles for article headings */
-  main :global(h1),
-  main :global(h2),
-  main :global(h3),
-  main :global(h4),
-  main :global(h5),
-  main :global(h6) {
+  main :global(:is(h1, h2, h3, h4, h5, h6)) {
     scroll-margin-top: 5rem;
   }
 
@@ -181,12 +176,7 @@ const { title, summary, published, id, image } = Astro.props;
 
   /* Desktop: show on heading hover */
   @media (hover: hover) {
-    main :global(h1:hover .anchor-link),
-    main :global(h2:hover .anchor-link),
-    main :global(h3:hover .anchor-link),
-    main :global(h4:hover .anchor-link),
-    main :global(h5:hover .anchor-link),
-    main :global(h6:hover .anchor-link) {
+    main :global(:is(h1, h2, h3, h4, h5, h6):hover .anchor-link) {
       opacity: 1;
     }
   }

--- a/src/lib/anchor-link-icon.ts
+++ b/src/lib/anchor-link-icon.ts
@@ -1,0 +1,53 @@
+/**
+ * HAST node for the anchor link icon (Lucide Link2).
+ *
+ * Why we can't import @lucide/astro directly:
+ * rehype-autolink-headings runs at build time during markdown processing
+ * and requires HAST nodes (HTML Abstract Syntax Tree), not Astro components.
+ * The @lucide/astro package provides Astro components which can't be used here.
+ */
+export const anchorLinkIcon = {
+  type: "element",
+  tagName: "svg",
+  properties: {
+    xmlns: "http://www.w3.org/2000/svg",
+    width: "20",
+    height: "20",
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: "1.5",
+    strokeLinecap: "round",
+    strokeLinejoin: "round",
+    "aria-hidden": "true",
+  },
+  children: [
+    {
+      type: "element",
+      tagName: "path",
+      properties: {
+        d: "M9 17H7A5 5 0 0 1 7 7h2",
+      },
+      children: [],
+    },
+    {
+      type: "element",
+      tagName: "path",
+      properties: {
+        d: "M15 7h2a5 5 0 1 1 0 10h-2",
+      },
+      children: [],
+    },
+    {
+      type: "element",
+      tagName: "line",
+      properties: {
+        x1: "8",
+        x2: "16",
+        y1: "12",
+        y2: "12",
+      },
+      children: [],
+    },
+  ],
+} as const;


### PR DESCRIPTION
## Summary
- Add clickable anchor links to all article headings for easy sharing/linking
- Extract HAST icon definition to `src/lib/anchor-link-icon.ts` for cleaner config
- Style anchor links with hover states, focus indicators, and touch device support
- Respect `prefers-reduced-motion` for transitions

## Test plan
- [ ] Run `pnpm build` - should complete without errors
- [ ] Run `pnpm dev` and navigate to an article
- [ ] Hover over headings - anchor link icon should appear
- [ ] Click anchor link - URL should update with heading ID
- [ ] Test keyboard navigation - focus states should be visible
- [ ] Test on touch device - icons should be visible at reduced opacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)