### PR TITLE
Add transition effects for article metadata and titles

### DIFF
--- a/src/layouts/Article.astro
+++ b/src/layouts/Article.astro
@@ -41,7 +41,7 @@ const { title, summary, published, id, image } = Astro.props;
 
       <aside class="meta">
         <ul>
-          <li>
+          <li transition:name={`post-meta-${id}`}>
             <Calendar size={18} stroke-width={1} />
 
             <time datetime={published.toISOString()}>
@@ -51,7 +51,7 @@ const { title, summary, published, id, image } = Astro.props;
 
           {
             summary && (
-              <li>
+              <li transition:name={`post-summary-${id}`}>
                 <FileText size={18} stroke-width={1} />
 
                 {summary}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -65,24 +65,20 @@ const description =
                   )}
 
                   <div class={data.image && "glass3d"}>
-                    <header>
-                      <h1 transition:name={`post-title-${id}`}>{data.title}</h1>
-                    </header>
+                    <h1 transition:name={`post-title-${id}`}>{data.title}</h1>
 
-                    <p>{data.summary}</p>
+                    <p transition:name={`post-summary-${id}`}>{data.summary}</p>
 
-                    <aside>
-                      <small>
-                        <Calendar
-                          size={16}
-                          stroke-width={1}
-                          style="vertical-align: text-top"
-                        />
-                        <time datetime={data.published.toISOString()}>
-                          {formatter.format(data.published)}
-                        </time>
-                      </small>
-                    </aside>
+                    <small transition:name={`post-meta-${id}`}>
+                      <Calendar
+                        size={16}
+                        stroke-width={1}
+                        style="vertical-align: text-top"
+                      />
+                      <time datetime={data.published.toISOString()}>
+                        {formatter.format(data.published)}
+                      </time>
+                    </small>
                   </div>
                 </article>
               </a>


### PR DESCRIPTION
```
### Description

This pull request introduces transition effects for article metadata and titles to improve visual aesthetics and enhance user experience.

### Related Issues

N/A

### Checklist

- [ ] Tests have been added as needed.
- [ ] Documentation has been updated to reflect these changes.
```